### PR TITLE
Fix blank interactive score pages (Mozart & Webern): dead Verovio toolkit URL + 4.x API breakages

### DIFF
--- a/scored-up-scores/Mozart/Mozart.html
+++ b/scored-up-scores/Mozart/Mozart.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>Marked-up Mozart</title>
-        <script src="http://www.verovio.org/javascript/develop/verovio-toolkit.js" type="text/javascript" ></script>
+        <script src="https://www.verovio.org/javascript/4.3.1/verovio-toolkit.js" type="text/javascript" ></script>
         <script src="https://code.jquery.com/jquery-3.1.1.min.js" type="text/javascript" ></script>
         <script src="../javascript/basic-events.js" type="text/javascript" ></script>
         <link rel="stylesheet" href="../css/tutorial.css" />
@@ -19,7 +19,7 @@
         <div id="svg_output"/>
 
         <script type="text/javascript">
-            var vrvToolkit = new verovio.toolkit();
+            var vrvToolkit;
             var page = 1;
             var zoom = 50;
             var pageHeight = 2970;
@@ -80,8 +80,6 @@
                     //     }
                     //     });
 
-                }
-
                 else if (choice == 2) {
 
                     $(".measure .staff:nth-child(1)" ).attr("fill", "#00e").attr("stroke", "#00e");
@@ -100,6 +98,9 @@
                     console.log("Unknown choice");
                 }
             }
+
+            function startVerovio() {
+            vrvToolkit = new verovio.toolkit();
 
             $( document ).ready(function() {
 
@@ -128,6 +129,13 @@
                     }
                 });
             });
+            }
+
+            if (verovio.module && verovio.module.calledRun) {
+                startVerovio();
+            } else {
+                verovio.module.onRuntimeInitialized = startVerovio;
+            }
         </script>
     </body>
 </html>

--- a/scored-up-scores/Webern/Webern-Symphonie.html
+++ b/scored-up-scores/Webern/Webern-Symphonie.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>Webern Website</title>
-        <script src="https://www.verovio.org/javascript/develop/verovio-toolkit.js" type="text/javascript" ></script>
+        <script src="https://www.verovio.org/javascript/4.3.1/verovio-toolkit.js" type="text/javascript" ></script>
         <script src="https://code.jquery.com/jquery-3.1.1.min.js" type="text/javascript" ></script>
         <script src="../javascript/basic-events.js" type="text/javascript" ></script>
         <link rel="stylesheet" href="../css/tutorial.css" />
@@ -31,7 +31,7 @@
         <div id="svg_output"/>
 
         <script type="text/javascript">
-            var vrvToolkit = new verovio.toolkit();
+            var vrvToolkit;
             var page = 1;
             var zoom = 50;
             var pageHeight = 2970;
@@ -49,7 +49,7 @@
                             pageWidth: pageWidth,
                             scale: zoom,
                             adjustPageHeight: 1,
-                            ignoreLayout: 1
+                            breaks: "auto"
                         };
                 vrvToolkit.setOptions( options );
             }
@@ -65,7 +65,7 @@
             /* Load the page and highlight according to the current choice */
 
             function loadPage() {
-                svg = vrvToolkit.renderPage(page, {});
+                svg = vrvToolkit.renderToSVG(page, {});
                 $("#svg_output").html(svg);
 
                 if (choice == 1) {
@@ -157,6 +157,9 @@
                 }
             }
 
+            function startVerovio() {
+            vrvToolkit = new verovio.toolkit();
+
             $( document ).ready(function() {
 
                 $(window).keyup(function(event){
@@ -184,6 +187,13 @@
                     }
                 });
             });
+            }
+
+            if (verovio.module && verovio.module.calledRun) {
+                startVerovio();
+            } else {
+                verovio.module.onRuntimeInitialized = startVerovio;
+            }
         </script>
     </body>
 </html>


### PR DESCRIPTION
## Problem

The interactive score pages render blank:

- `scored-up-scores/Mozart/Mozart.html`
- `scored-up-scores/Webern/Webern-Symphonie.html`

Both load the Verovio toolkit from the **dead `/develop/` channel**, which now returns a GitHub Pages 404:

```
https://www.verovio.org/javascript/develop/verovio-toolkit.js  ->  404
```

With the toolkit missing, the `verovio` global never exists, the score SVG is never drawn, and the viewer stays empty. (A 404 on `<script src>` fails silently, so the console looks clean.) Mozart additionally referenced it over `http://`, which is blocked as mixed content on the HTTPS site.

Once the URL is fixed, a few more breakages surface because the page was written against a very old (`rism-ch/verovio-tutorial`-era) toolkit:

- **Mozart** had a stray `}` before `else if (choice == 2)`, causing `SyntaxError: ... 'else'` that voided the entire inline script (so `$(document).ready(...)` never ran).
- **Webern** called `renderPage()`, which was renamed to `renderToSVG()` in Verovio 4.x.
- **Webern** passed `ignoreLayout`, which is no longer a supported option in 4.x (logged an error).

## Fix

- Repoint both pages to a **pinned, live** build: `https://www.verovio.org/javascript/4.3.1/verovio-toolkit.js` (versioned rather than a moving channel like `develop`/`latest`, which is what broke this).
- Mozart: remove the stray `}`.
- Webern: `renderPage()` -> `renderToSVG()`; `ignoreLayout` -> `breaks: "auto"` (faithful 4.x equivalent of "ignore the encoded layout").
- Gate toolkit creation so it works whether the runtime is already initialized (the synchronous asm.js build, which is the current behaviour) **or** initializes asynchronously (the WASM build), making the page resilient to a future build swap.

## Verification

Tested locally with headless Chrome against the served site:

| Page | Renders SVG | Keypress highlighting | Console errors |
|------|-------------|-----------------------|----------------|
| Mozart | ✅ | ✅ 1 / 2 / 3 | none |
| Webern | ✅ | ✅ 1 / 2 / 3 / 4 / 0 | none |

## Note

`Webern`'s `setOptions()` derives `pageHeight` from `$(document).height()` at load time, so on a small window the longer excerpt can paginate and the cross-measure highlights for later measures land off page 1. This is pre-existing behaviour, not introduced here; if desired, switching `breaks: "auto"` -> `breaks: "none"` forces the whole excerpt onto a single page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)